### PR TITLE
chore: 2021.6 compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "iq_notify",
     "name": "IqNotify",
+    "version": "1.0.0",
     "requirements": [],
     "dependencies": [],
     "codeowners": []


### PR DESCRIPTION
Adds a version to the manifest.json for compatibility with 2021.6. Fixes #1