### PR TITLE
Add just_left_then_away mode, and other cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Therefore you must have access to your Home Assistant files, no Add-on avilable.
 - Notify people that are present at home for particular time. (`staying_home`)
 - Notify people that are away from home for particular time. (`staying_away`)
 - Try to notify people at home, but if none – notify people away. (`only_home_then_away`)
+- Try to notify people that just left home, but if none – notify people away. (`just_left_then_away`)
 
 ## Configuration reference
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## How to install
 
-1. Clone repository into $HASS_HOME/custom_components/iq_notify.
+1. Clone repository into \$HASS_HOME/custom_components/iq_notify.
 2. Update your configuration.yaml.
 
 The contents of this repository should be in a directory named `iq_notify` inside `custom_components` of your Home Assistant.
@@ -11,26 +11,26 @@ Therefore you must have access to your Home Assistant files, no Add-on avilable.
 
 ## How can you notify?
 
-* Notify only people present at home. (`only_home`)
-* Notify only people away from home. (`only_away`)
-* Notify people that just arrived home. (`just_arrived`)
-* Notify people that just left home. (`just_left`)
-* Notify people that are present at home for particular time. (`staying_home`)
-* Notify people that are away from home for particular time. (`staying_away`)
-* Try to notify people at home, but if none – notify people away. (`only_home_then_away`)
+- Notify only people present at home. (`only_home`)
+- Notify only people away from home. (`only_away`)
+- Notify people that just arrived home. (`just_arrived`)
+- Notify people that just left home. (`just_left`)
+- Notify people that are present at home for particular time. (`staying_home`)
+- Notify people that are away from home for particular time. (`staying_away`)
+- Try to notify people at home, but if none – notify people away. (`only_home_then_away`)
 
 ## Configuration reference
 
 ```yaml
 notify:
   - platform: iq_notify # the platform to use
-    name: iphones       # alias name for notify.{name}
-    time: 2             # time offset in which we assume someone "just left/arrived" or "is staying"
-    pairs:              # a list of presence entities are corresponding notify services
-      - entity: binary_sensor.presence_he  # presence entity id #1
-        service: his_iphone                # notify service to use for above entity, without domain (notify.)
+    name: iphones # alias name for notify.{name}
+    time: 2 # time offset in which we assume someone "just left/arrived" or "is staying"
+    pairs: # a list of presence entities are corresponding notify services
+      - entity: binary_sensor.presence_he # presence entity id #1
+        service: his_iphone # notify service to use for above entity, without domain (notify.)
       - entity: binary_sensor.presence_she # presence entity id #2
-        service: her_iphone                # notify service to use for above entity, without domain (notify.)
+        service: her_iphone # notify service to use for above entity, without domain (notify.)
 ```
 
 > `time` (defaults to 2)
@@ -40,7 +40,7 @@ notify:
 > `entity` (required)
 >
 > ID of any entity that state for "present" is `on` or `home` and `off` or `not_home` for "away".
-> Can be `input_boolean`, `binary_sensor `, `group`, `switch`, `device_tracker` etc.
+> Can be `input_boolean`, `binary_sensor`, `group`, `switch`, `device_tracker` etc.
 
 > `service` (required)
 >
@@ -51,15 +51,15 @@ notify:
 ##### Send notification only to people that are present at home.
 
 ```yaml
-- alias: 'Notify: on garbage disposal'
+- alias: "Notify: on garbage disposal"
   trigger:
     platform: state
     entity_id: calendar.garbage_disposal
-    to: 'on'
+    to: "on"
   condition:
     condition: state
     entity_id: binary_sensor.people_present
-    state: 'on'
+    state: "on"
   action:
     - service: notify.iphones
       data:
@@ -75,28 +75,27 @@ If there is someone present – notify people that are present that today is the
 
 ```yaml
 automation:
+  - alias: "Alarm: arm away when everyone left"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.people_present
+      to: "off"
+    action:
+      - service: alarm_control_panel.alarm_arm_away
+        entity_id: alarm_control_panel.alarm
 
-- alias: 'Alarm: arm away when everyone left'
-  trigger:
-    platform: state
-    entity_id: binary_sensor.people_present
-    to: 'off'
-  action:
-    - service: alarm_control_panel.alarm_arm_away
-      entity_id: alarm_control_panel.alarm
-
-- alias: 'Alarm: send notification on arming'
-  trigger:
-    - platform: state
-      entity_id: alarm_control_panel.alarm
-      to: 'armed_away'
-  action:
-    - service: notify.iphones
-      data:
-        title: Alarm
-        message: Alarm has been armed.
+  - alias: "Alarm: send notification on arming"
+    trigger:
+      - platform: state
+        entity_id: alarm_control_panel.alarm
+        to: "armed_away"
+    action:
+      - service: notify.iphones
         data:
-          mode: just_left
+          title: Alarm
+          message: Alarm has been armed.
+          data:
+            mode: just_left
 ```
 
 First automation tracks if everyone left home. If so – arms the alarm. After alarm is armed – second notification notifies only the person who "just left" that the alarm was armed successfully. The last person is responsible for arming the alarm.
@@ -105,20 +104,19 @@ First automation tracks if everyone left home. If so – arms the alarm. After a
 
 ```yaml
 automation:
-
-- alias: 'Door: remind on garage door kept opened'
-  trigger:
-    platform: state
-    entity_id: binary_sensor.garage_door_contact
-    to: 'on'
-    for: '00:05:00'
-  action:
-    - service: notify.iphones
-      data:
-        title: Garage door
-        message: Garage door kept opened for 5mins.
+  - alias: "Door: remind on garage door kept opened"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.garage_door_contact
+      to: "on"
+      for: "00:05:00"
+    action:
+      - service: notify.iphones
         data:
-          mode: only_home_then_away
+          title: Garage door
+          message: Garage door kept opened for 5mins.
+          data:
+            mode: only_home_then_away
 ```
 
-Will let know inmates that are home about the door that are not closed, but should be. They are home so they can close it. Otherwise if no one is home – let everyone know, because it might be a security breach.
+Will let users that are home know about the door that is left open. If no one is home, let everyone know (because it might be a security breach).

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "iq_notify",
     "name": "IqNotify",
+    "version": "1.0.0",
     "requirements": [],
     "dependencies": [],
     "codeowners": []

--- a/notify.py
+++ b/notify.py
@@ -126,30 +126,35 @@ class IqNotify(BaseNotificationService):
                 _LOGGER.debug('Entity: ' + entity + ' current state: ' +
                               str(cur_state) + ' since: ' + str(state_since))
 
+                if cur_state == STATE_ON or cur_state == STATE_HOME:
+                    user_is_home = True
+                else:
+                    user_is_home = False
+                
                 notify = False
-
+                
                 if mode == MODE_ALL:
                     notify = True
-                elif mode == MODE_ONLY_HOME and (cur_state == STATE_ON or cur_state == STATE_HOME):
+                elif mode == MODE_ONLY_HOME and user_is_home:
                     notify = True
-                elif mode == MODE_ONLY_AWAY and (cur_state == STATE_OFF or cur_state == STATE_NOT_HOME):
+                elif mode == MODE_ONLY_AWAY and not user_is_home:
                     notify = True
-                elif mode == MODE_JUST_ARRIVED and (cur_state == STATE_ON or cur_state == STATE_HOME):
+                elif mode == MODE_JUST_ARRIVED and user_is_home:
                     if looking_since < state_since:
                         notify = True
-                elif mode == MODE_JUST_LEFT and (cur_state == STATE_OFF or cur_state == STATE_NOT_HOME):
+                elif mode == MODE_JUST_LEFT and not user_is_home:
                     if looking_since < state_since:
                         notify = True
-                elif mode == MODE_STAYING_HOME and (cur_state == STATE_ON or cur_state == STATE_HOME):
+                elif mode == MODE_STAYING_HOME and user_is_home:
                     if looking_since > state_since:
                         notify = True
-                elif mode == MODE_STAYING_AWAY and (cur_state == STATE_OFF or cur_state == STATE_NOT_HOME):
+                elif mode == MODE_STAYING_AWAY and not user_is_home:
                     if looking_since > state_since:
                         notify = True
                 elif mode == MODE_ONLY_HOME_THEN_AWAY:
                     if not anyone_home:
                         notify = True
-                    elif anyone_home and (cur_state == STATE_ON or cur_state == STATE_HOME):
+                    elif anyone_home and user_is_home:
                         notify = True
 
                 if notify:

--- a/notify.py
+++ b/notify.py
@@ -97,7 +97,7 @@ class IqNotify(BaseNotificationService):
                 time = data.get(CONF_TIME)
                 data.pop(CONF_TIME)
 
-        _LOGGER.debug('IqNotify: using mode: ' + mode)
+        _LOGGER.debug('IqNotify: using mode: ' + mode + ' and message: ' + message)
 
         looking_since = dt_util.utcnow() - timedelta(minutes=time)
         
@@ -136,9 +136,7 @@ class IqNotify(BaseNotificationService):
                 state = self.hass.states.get(entity)
                 cur_state = state.state
                 state_since = state.last_changed
-                _LOGGER.debug('Entity: ' + entity + ' current state: ' +
-                              str(cur_state) + ' since: ' + str(state_since))
-
+                
                 if cur_state == STATE_ON or cur_state == STATE_HOME:
                     user_is_home = True
                 else:
@@ -177,8 +175,14 @@ class IqNotify(BaseNotificationService):
                             if looking_since < state_since:
                                 notify = True
 
+                _LOGGER.debug('\nentity: ' + entity)
+                _LOGGER.debug('cur_state: ' + str(cur_state))
+                _LOGGER.debug('looking_since: ' + str(looking_since))
+                _LOGGER.debug('state_since: ' + str(state_since))
+                _LOGGER.debug('looking_since < state_since: ' + str(looking_since < state_since))
+                _LOGGER.debug('user_is_home: ' + str(user_is_home))
+                _LOGGER.debug('anyone_just_left: ' + str(anyone_just_left))
 
                 if notify:
                     self.hass.services.call('notify', service, service_data)
-                    _LOGGER.info('Notifying notify.' + service +
-                                 ' via ' + mode + ' mode')
+                    _LOGGER.info('Notifying notify.' + service + ' via ' + mode + ' mode' + '\n');

--- a/notify.py
+++ b/notify.py
@@ -26,25 +26,25 @@ DEFAULT_TIME = 2  # minutes
 # send notification to all, default
 MODE_ALL = 'all'
 
-# send notification to only present inmates
+# send notification to only present users
 MODE_ONLY_HOME = 'only_home'
 
-# send notification to only away inmates
+# send notification to only away users
 MODE_ONLY_AWAY = 'only_away'
 
-# send notification to inmates that arrived in last CONF_TIME
+# send notification to users that arrived in last CONF_TIME
 MODE_JUST_ARRIVED = 'just_arrived'
 
-# send notification to inmates that left in last CONF_TIME
+# send notification to users that left in last CONF_TIME
 MODE_JUST_LEFT = 'just_left'
 
-# send notification to present inmates that are present for at least CONF_TIME
+# send notification to present users that are present for at least CONF_TIME
 MODE_STAYING_HOME = 'staying_home'
 
-# send notification to away inmates that are away for at least CONF_TIME
+# send notification to away users that are away for at least CONF_TIME
 MODE_STAYING_AWAY = 'staying_away'
 
-# try to send notification to present but if no one present - send to away inmates
+# try to send notification to present but if no one present - send to away users
 MODE_ONLY_HOME_THEN_AWAY = 'only_home_then_away'
 
 PAIRS_CONFIG_SCHEMA = vol.Schema({

--- a/notify.py
+++ b/notify.py
@@ -21,16 +21,31 @@ CONF_PAIR_SERVICE = 'service'
 CONF_TIME = 'time'
 CONF_MODE = 'mode'
 
-DEFAULT_TIME = 2 # minutes
+DEFAULT_TIME = 2  # minutes
 
-MODE_ALL = 'all'                                    # send notification to all, default
-MODE_ONLY_HOME = 'only_home'                        # send notification to only present inmates
-MODE_ONLY_AWAY = 'only_away'                        # send notification to only away inmates
-MODE_JUST_ARRIVED = 'just_arrived'                  # send notification to inmates that arrived in last CONF_TIME
-MODE_JUST_LEFT = 'just_left'                        # send notification to inmates that left in last CONF_TIME
-MODE_STAYING_HOME = 'staying_home'                  # send notification to present inmates that are present for at least CONF_TIME
-MODE_STAYING_AWAY = 'staying_away'                  # send notification to away inmates that are away for at least CONF_TIME
-MODE_ONLY_HOME_THEN_AWAY = 'only_home_then_away'    # try to send notification to present but if no one present - send to away inmates
+# send notification to all, default
+MODE_ALL = 'all'
+
+# send notification to only present inmates
+MODE_ONLY_HOME = 'only_home'
+
+# send notification to only away inmates
+MODE_ONLY_AWAY = 'only_away'
+
+# send notification to inmates that arrived in last CONF_TIME
+MODE_JUST_ARRIVED = 'just_arrived'
+
+# send notification to inmates that left in last CONF_TIME
+MODE_JUST_LEFT = 'just_left'
+
+# send notification to present inmates that are present for at least CONF_TIME
+MODE_STAYING_HOME = 'staying_home'
+
+# send notification to away inmates that are away for at least CONF_TIME
+MODE_STAYING_AWAY = 'staying_away'
+
+# try to send notification to present but if no one present - send to away inmates
+MODE_ONLY_HOME_THEN_AWAY = 'only_home_then_away'
 
 PAIRS_CONFIG_SCHEMA = vol.Schema({
     vol.Optional(CONF_PAIR_ENTITY): cv.string,
@@ -42,14 +57,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TIME, default=DEFAULT_TIME): cv.positive_int
 })
 
+
 def get_service(hass, config, discovery_info=None):
     """Get the notification service."""
-    _LOGGER.debug('Setting up iq_notify platform...');
+    _LOGGER.debug('Setting up iq_notify platform...')
 
     pairs = config[CONF_PAIRS]
     time = config[CONF_TIME]
 
     return IqNotify(pairs, time)
+
 
 class IqNotify(BaseNotificationService):
 
@@ -76,7 +93,7 @@ class IqNotify(BaseNotificationService):
                 time = data.get(CONF_TIME)
                 data.pop(CONF_TIME)
 
-        _LOGGER.debug('IqNotify: using mode: ' + mode);
+        _LOGGER.debug('IqNotify: using mode: ' + mode)
 
         # Check if there's anyone home (for MODE_ONLY_HOME_THEN_AWAY)
         anyone_home = False
@@ -106,7 +123,8 @@ class IqNotify(BaseNotificationService):
                 state = self.hass.states.get(entity)
                 cur_state = state.state
                 state_since = state.last_changed
-                _LOGGER.debug('Entity: ' + entity + ' current state: ' + str(cur_state) + ' since: ' + str(state_since))
+                _LOGGER.debug('Entity: ' + entity + ' current state: ' +
+                              str(cur_state) + ' since: ' + str(state_since))
 
                 notify = False
 
@@ -136,4 +154,5 @@ class IqNotify(BaseNotificationService):
 
                 if notify:
                     self.hass.services.call('notify', service, service_data)
-                    _LOGGER.info('Notifying notify.' + service + ' via ' + mode + ' mode');
+                    _LOGGER.info('Notifying notify.' + service +
+                                 ' via ' + mode + ' mode')


### PR DESCRIPTION
The biggest feature here is the addition of `just_left_then_away` mode. This is useful, for example, the case where an alarm system is being armed to Away. If someone is just detected as having left, notify them. But if no one is detected as having just left, notify everyone who is away.

I've done some code and terminology cleanup here as well. (The term "inmates" typically refers to prisoners—not the best description of use case here, I imagine.)